### PR TITLE
Add ccthread to Context and Memory Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Workflows for managing Claude Code's context window, memory persistence, and ses
 - [runesleo/claude-code-workflow](https://github.com/runesleo/claude-code-workflow) - Battle-tested template for memory management, context engineering, and task routing from 3 months of daily usage. 521 stars.
 - [cartographer](https://github.com/kingbootoshi/cartographer) - Plugin that maps and documents codebases of any size using parallel AI subagents. 522 stars.
 - [vinicius91carvalho/.claude](https://github.com/vinicius91carvalho/.claude) - Portable workflow system with hooks, agents, skills, and enforcement. Drop-in `.claude/` directory that brings structured context management to any project.
+- [ccthread](https://github.com/jakemarsh/ccthread) - Plugin + CLI that reads conversation logs from `~/.claude/projects/` and turns them into clean markdown. `ccthread show current --before-last-compact` recovers what the agent said before the context window got compacted.
 
 ## TDD and Code Quality
 


### PR DESCRIPTION
## Summary

Adds [ccthread](https://github.com/jakemarsh/ccthread) to Context and Memory Management, alongside [claude-mem](https://github.com/thedotmack/claude-mem), [Continuous Claude v3](https://github.com/parcadei/Continuous-Claude-v3), and [claude-code-workflow](https://github.com/runesleo/claude-code-workflow) — same problem space (conversation context), different angle.

ccthread reads Claude Code session `.jsonl` files directly and emits clean markdown. The workflow that makes it a Context/Memory fit is `ccthread show current --before-last-compact`: recover what the agent said before Claude Code compacted the context window.

Tagline: *Read, search, and have Claude summarize your Claude Code conversation logs from the CLI.*

## License

MIT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ccthread` resource to the Context and Memory Management curated list with repository link and usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->