### PR TITLE
Add claude-verify-before-stop (Stop hook against 'lies of completion')

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Workflows that enforce test-driven development and automated code quality checks
 - [Superpowers code review loop](https://github.com/obra/superpowers) - Two-skill combo: `/requesting-code-review` prepares the request, `/receiving-code-review` processes feedback. Uses a dedicated code-reviewer agent.
 - [claude-pipeline](https://github.com/aaddrick/claude-pipeline) - Portable multi-agent pipeline with skills, agents, hooks, orchestration scripts, and quality gates. 97 stars.
 - [glebis/claude-skills TDD](https://github.com/glebis/claude-skills) - Multi-agent TDD orchestration with architecturally enforced context isolation via Claude Code's Task tool. Interactive mode pauses at each RED checkpoint; autonomous mode runs all slices end-to-end.
+- [claude-verify-before-stop](https://github.com/ianymu/claude-verify-before-stop) - Stop hook that blocks session end if files changed but no verification log entry exists in the last 5 minutes. Forces the agent to either prove it verified (tests/curl/playwright/psql) or admit it didn't — kills "lies of completion" like *"All tests passing ✅"* when they aren't. Pure bash, zero deps.
 
 ## Git and PR Automation
 


### PR DESCRIPTION
Adding a small open-source Stop hook for Claude Code: **[claude-verify-before-stop](https://github.com/ianymu/claude-verify-before-stop)**.

**What it does**
A Stop hook that blocks Claude Code from ending the session if files were changed but no verification was logged in the last 5 minutes. The agent has to either:
- Run real verification (tests, curl, playwright, psql, etc.) and log `VERIFIED` to `.claude/state/stop-verify.log`, **or**
- Admit it didn't verify

This stops the *"All tests passing ✅"* → merge → production-breaks → 2h debugging regression cycle that's the #1 problem of long-running Claude Code sessions.

**Why it fits TDD and Code Quality**
- Same goal as `Superpowers TDD` and `gstack QA`: enforce verification before completion claims.
- Different lever: it's a **Stop hook** (lifecycle gate), not a slash command or skill — works alongside any TDD workflow you already use.
- Pure bash + python3 stdlib. MIT licensed. ~60s install.

Inserted right after the existing TDD/quality workflow entries. Happy to adjust wording or placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `claude-verify-before-stop` workflow entry, describing a stop hook that prevents session termination when file changes are detected without recent verification log entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ithiria894/awesome-claude-code-workflows/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->