### PR TITLE
Add: retro-daily — SessionStart hook + background scout workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Workflows for tracking Claude Code activity and visualizing progress.
 - [claude-hud](https://github.com/jarrodwatts/claude-hud) - Plugin that shows real-time context usage, active tools, running agents, and todo progress as a dashboard overlay. 11,537 stars.
 - [cc-context-stats](https://github.com/luongnv89/cc-context-stats) - Real-time Model Intelligence (MI) score in your status bar — calibrated from Anthropic's MRCR benchmark per model (Opus/Sonnet/Haiku). Live ASCII dashboard tracks context growth, MI degradation, and token I/O. Five color-coded zones tell you when to plan, when to code-only, and when to start fresh. Python, Node.js, and Bash implementations.
 - [ccproxy](https://github.com/starbaser/ccproxy) - Proxy that hooks into Claude Code requests for intelligent model routing, request/response modification, and LangFuse tracking. 189 stars.
+- [retro-daily](https://github.com/gyanesh-m/retro-daily) - Competency dashboard rendered at session start, combining a `SessionStart` hook (0–100 grade, A–F letter, 14-day efficiency sparklines, year heatmap) + a detached `claude -p` background scout worker that researches your weakest metrics on docs.anthropic.com and GitHub between sessions + a Python metrics layer over `~/.claude/projects/*.jsonl`. Findings surface inline in the next session.
 
 ## Comprehensive Frameworks
 


### PR DESCRIPTION
## What this adds

**[retro-daily](https://github.com/gyanesh-m/retro-daily)** — a recipe for using a `SessionStart` hook + a detached `claude -p` background worker together as a single workflow: at session start, render a competency dashboard (grade 0–100 / A–F, 14-day efficiency sparklines, year heatmap), then between sessions, the scout worker auto-researches your weakest metrics on `docs.anthropic.com` and GitHub. Findings surface inline in the NEXT session's dashboard.

Install:

```
/plugin marketplace add gyanesh-m/retro-daily
/plugin install retro-daily@retro-daily
/reload-plugins
```

- Repo: https://github.com/gyanesh-m/retro-daily
- Demo: https://gyanesh-m.github.io/retro-daily/
- License: MIT

## Why it fits this list

The list's framing is "workflow recipes that combine hooks, MCP servers, skills, agents." retro-daily is exactly that combination: SessionStart hook (UI surface) + detached `claude -p` worker (background research) + a small Python metrics layer (`generate-metrics.py`). The workflow is the point — neither half alone has the same value.

## Security and privacy disclosure

Reads local Claude Code session history from `~/.claude/projects/*.jsonl`. Writes derived state, logs, scout results, and session tags under `~/.claude/metrics`. By default, `scout.sh` and `tag-sessions.sh` start detached, sandboxed `claude -p` background workers (scout uses `WebSearch`+`Write`; tag-sessions denies network). Set `RETRO_DAILY_NO_BACKGROUND_WORKERS=1` to disable. Rate-limit with `SCOUT_STALE_DAYS` (default 7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for `retro-daily`, a new competency dashboard workflow in the Monitoring and Dashboards section for tracking and analyzing session metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ithiria894/awesome-claude-code-workflows/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->