### PR TITLE
Add TWZRD Agent Intel MCP — Solana x402 agent trust workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ All-in-one frameworks that bundle skills, hooks, agents, and commands into a sin
 
 ---
 
+## Web3 and Agent Payments
+
+Workflows that integrate decentralized payment protocols and on-chain trust verification into Claude Code agent pipelines.
+
+- [TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final) - Solana-native trust scoring MCP server with x402 payment receipts. Agents call the free preflight endpoint to score a counterparty, then pay for a signed V5 trust receipt via x402. Streamable-HTTP at https://intel.twzrd.xyz/mcp — add to `.mcp.json` to gate Claude Code workflows on agent trust scores.
+
 ## Related Awesome Lists
 
 - [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) - Comprehensive catalog of Claude Code tools, skills, hooks, agents, and plugins. 30K stars.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ All-in-one frameworks that bundle skills, hooks, agents, and commands into a sin
 
 Workflows that integrate decentralized payment protocols and on-chain trust verification into Claude Code agent pipelines.
 
-- [TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final) - Solana-native trust scoring MCP server with x402 payment receipts. Agents call the free preflight endpoint to score a counterparty, then pay for a signed V5 trust receipt via x402. Streamable-HTTP at https://intel.twzrd.xyz/mcp — add to `.mcp.json` to gate Claude Code workflows on agent trust scores.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Solana-native trust scoring MCP server with x402 payment receipts. Agents call the free preflight endpoint to score a counterparty, then pay for a signed V5 trust receipt via x402. Streamable-HTTP at https://intel.twzrd.xyz/mcp — add to `.mcp.json` to gate Claude Code workflows on agent trust scores.
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
## Summary

- Adds a new **Web3 and Agent Payments** section to the workflow catalog
- TWZRD Agent Intel enables trust-gated Claude Code workflows via x402 payment protocol
- Real-world workflow: agent preflight scores a counterparty → pays for signed trust receipt → proceeds with transaction

## Details

**TWZRD Agent Intel** is a Solana-native MCP server that fits as the trust/payment verification layer in any agent workflow:

1. Call the free preflight endpoint to score a counterparty's on-chain trust history
2. Pay for a signed V5 trust receipt via HTTP 402 (x402 micropayment protocol)
3. Gate downstream Claude Code actions on the trust score result

MCP endpoint (Streamable-HTTP): https://intel.twzrd.xyz/mcp  
Source: https://intel.twzrd.xyz

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Web3 and Agent Payments" section describing workflows that integrate decentralized payment protocols and on-chain trust verification into Claude Code agent pipelines.
  * Added a reference entry for TWZRD Agent Intel outlining Solana-native trust scoring and payment/receipt verification flows implemented via an intermediary server, including preflight validation and gating options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->