### PR TITLE
Add NotFair (SEO, Google Ads & Meta Ads skills + MCP workflows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Workflows for content creation, social media posting, and distribution.
 - [Agency Agents marketing suite](https://github.com/msitarzewski/agency-agents) - 156 agent persona files across 13 categories including marketing, engineering, design, sales, and more. Install script converts to Claude Code, Cursor, or Copilot format. By Michael Sitarzewski. Codex-verified counts. 15K stars.
 - [OPC Skills solopreneur marketing](https://github.com/ReScienceLab/opc-skills) - 10 standalone skills for solopreneurs: SEO/GEO optimization, Reddit research, Product Hunt search, domain hunting, logo creation, banner creation. 612 stars.
 - [Everything Claude Code content engine](https://github.com/affaan-m/everything-claude-code) - Skills for article writing, market research, and investor materials.
+- [NotFair](https://github.com/nowork-studio/NotFair) - Claude Code skills for SEO, GEO, Google Ads, and Meta Ads, pulling live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Skills cover site analysis, keyword research, meta tags, schema markup, ad audits, wasted-spend detection, and creative-fatigue analysis. ~2.9k stars.
 
 ## Business Operating Systems
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a great resource.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair) to the **Marketing and Content** section. It's a set of Claude Code skills for SEO, GEO, Google Ads, and Meta Ads work. What makes it a workflow rather than a single skill is that it chains multiple Claude Code primitives together: the skills pull live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, then run analysis and surface recommendations — all in one session. It covers things like site audits, keyword research, meta-tag optimization, schema markup, ad spend audits, wasted-spend detection, and Meta creative-fatigue checks. It has around ~2.9k stars on GitHub.

Happy to reword, move it to a different section, or trim the description if you prefer a shorter format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new marketing and content workflow entry to the README documenting capabilities for digital marketing optimization. The entry covers SEO, geographic targeting, and advertising platform management across Google Ads, Meta Ads, Google Search Console, and GA4, including site analysis, keyword research, ad audits, and fatigue analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->