### PR TITLE
Add aigent-OS to Comprehensive Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ All-in-one frameworks that bundle skills, hooks, agents, and commands into a sin
 - [CloudAI-X/claude-workflow-v2](https://github.com/CloudAI-X/claude-workflow-v2) - Universal Claude Code workflow plugin with agents, skills, hooks, and commands combined into one installable package. 1,301 stars.
 - [shanraisshan/claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) - Trending on GitHub March 2026. Interactive examples of Command → Agent → Skill orchestration pattern. Shows how to chain commands into multi-step workflows with reports and verification gates.
 - [luongnv89/claude-howto](https://github.com/luongnv89/claude-howto) - Visual 10-module guide showing how to combine slash commands + hooks + skills + subagents + MCP into end-to-end workflows. Copy-paste templates for automated code review, CI/CD automation, and security audit pipelines.
+- [aigent-OS](https://github.com/wrg32786/aigent-os) - Full personal-operator OS on top of Claude Code: 64 skills, a 9-agent subagent Pantheon, 17 background daemons, 7 hook scripts, and a 15-document operating kernel (identity, ethos, decision frameworks, delegation protocol), all synced to a persistent Obsidian vault via an `/open` + `/close` session rhythm that loads and banks context across sessions. Adds a cognitive layer on top — self-model, goal stack, belief tracking, memory decay. Markdown + shell only, no database, server, or build step. By Will G (wrg32786). MIT. New public release (0 stars).
 
 ---
 


### PR DESCRIPTION
## What this is

[aigent-OS](https://github.com/wrg32786/aigent-os) — a full personal-operator OS built on top of Claude Code. It's the daily-driver system I run my own Claude Code sessions through (this PR itself was drafted inside it), so this is a submission I've actually used, not something evaluated cold.

**Primitives combined (satisfies the 2+ requirement):**
- **64 skills** (`skills/`) — slash-command workflows for memory, planning, delegation, review
- **9-agent subagent Pantheon** (`vault/agents/`) — named specialist instruments (Lyra, Iris, Hypatia, Vitruvius, Mnemosyne, Newton, Echo, Demosthenes, Hestia)
- **17 background daemons** (`daemons/`) — Caddy skill router, semantic search, memory-heat, runtime consciousness state
- **7 hooks** (`hooks/`) — session-start/session-end capture, token tracking, compact nudges, security scan
- **15-document operating kernel** (`system/00_identity.md` → `system/15_somatic_layer.md`) — identity, ethos, decision frameworks, delegation protocol — playing the role CLAUDE.md usually plays, but versioned and numbered
- **CLAUDE.md + Obsidian vault** — persistent memory across sessions via an `/open` + `/close` session rhythm that loads context in and banks it back out

On top of that it has a cognitive layer that's less common in these frameworks: a persistent self-model, a goal stack, belief tracking with confidence scores, and memory-decay/consolidation (`/dream`) passes.

**Dependency model:** markdown + shell only. No database, no server, no build step. Optional features (semantic search, hook automation) use Node.js if present, but the core kernel has zero runtime dependency.

## Curation checklist (per CONTRIBUTING.md)

- [x] Actually used, not just evaluated — it's my standing operating layer
- [x] Combines 2+ Claude Code primitives — skills + hooks + subagents + daemons + CLAUDE.md-equivalent kernel, all listed above with real counts
- [x] Actively maintained — public repo pushed same day as this PR
- [x] Description starts with capital letter, ends with period
- [x] Added to the end of Comprehensive Frameworks, matching the existing convention of appending no-star-count entries after the star-ranked ones

## Honesty on stars

This is a brand-new public release (0 stars, repo made public today) — flagging that plainly rather than dressing it up. The substance is the years of daily internal use behind it, not social proof yet. Happy to have it held for a bit if you'd rather wait and see it mature publicly first — just didn't want to submit without disclosing where it stands.

MIT licensed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new framework entry to the comprehensive frameworks list, including a short description, repository link, author information, license, and a note about a new public release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->