### PR TITLE
Add batch-fix-bugs to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Workflows that coordinate multiple AI agents working in parallel or sequence.
 - [agent-council](https://github.com/team-attention/agent-council) - Multi-agent collaboration plugin orchestrating multiple AI agents (Codex CLI, Gemini CLI) for diverse perspectives on the same task. 118 stars.
 - [Solopreneur kickoff](https://github.com/pcatattacks/solopreneur-plugin) - Agent team meetings where 6 specialist agents debate approach before building.
 - [wshobson/agents](https://github.com/wshobson/agents) - Intelligent automation and multi-agent orchestration for Claude Code with specialized agent roles and coordinated task execution.
+- [batch-fix-bugs](https://github.com/DonChengCheng/batch-fix-bugs) - Each bug gets its own git worktree and fix agent, then an independent reviewer re-reads the original issue and argues against the diff. Three-way verdicts (pass / needs-human / reject), nothing auto-committed — output is a triage report for a human.
 
 ## Context and Memory Management
 


### PR DESCRIPTION
### What it is

A batch bug-fixing recipe. It pulls open issues from a tracker, gives each bug its own `git worktree` and its own fix agent, then hands the resulting diff to a **separate** reviewer agent that re-reads the original issue itself and argues against the fix.

The output is a three-way triage report. It does not commit, push, or write anything back to the tracker.

### Primitives combined

- **Slash command** (`/batch-fix-bugs`) — argument parsing, repo mapping, worktree setup, human confirmation gates
- **Workflow script** — `pipeline()` orchestration with no barrier between the fix and verify stages, so a bug that finishes fixing in 1 minute is already being reviewed while a 15-minute bug is still in stage one
- **Two subagent roles** — fixer and adversarial reviewer, deliberately given different information

### Why it might earn a slot

Most "AI fixes bugs" setups stop at generating the patch. The interesting problem starts right after: you have N patches that all claim success, and no way to tell which to trust without reading every line. The design choices here all aim at that.

- The reviewer is a **different agent**, and is deliberately **not** given the fixer's reasoning. Handed the reasoning, it starts judging whether the reasoning sounds plausible rather than whether the diff fixes the bug — which is far too easy to pass. It also re-fetches the original issue instead of trusting a summary, so a fixer that misread the expected behaviour can't propagate that misreading into the review.
- Verdicts are **three-way**, not pass/fail. Given only two options, an unsure model picks `pass`, because `reject` is the stronger claim and "I can't tell" has nowhere to go on that side. The binary shape manufactures false positives.
- Claims that can be checked deterministically are **not left to the model**. The main session re-runs `tsc`, the test suite, and `git status` itself rather than believing the agent's `checksRun` field.
- The "never write back without a real commit hash" rule is enforced **architecturally** — the workflow has no code path to the tracker at all — rather than by asking the model not to.

### Actually used

Run against a real project, not a demo. In one round the reviewer caught a fix whose four new tests all passed while none of them covered the part of the change that actually fixed the bug: reverting just that part left the suite green and the layout broken. The fixer had also reported a measurement it had inferred rather than measured.

### Tracker support

Trackers plug in through a small `list` / `show` / `check` adapter contract, roughly 60 lines each. Ships with mock (zero config, runs standalone so the pipeline can be exercised without touching a real system), GitHub Issues via `gh`, and ZenTao. The normalisation logic has tests — `node adapters/github.test.js` (21 cases) and `adapters/zentao.test.js` (14).

### Checklist

- [x] Actually used, not just evaluated
- [x] Combines 3 primitives (slash command + workflow script + subagents)
- [x] Last commit under 6 months old
- [x] Description starts with a capital letter and ends with a period
- [x] One workflow in this PR

Writeup with the full reasoning behind each decision (Chinese): https://juejin.cn/post/7673866197452472339


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `batch-fix-bugs` to the Multi-Agent Orchestration workflow documentation.
  * Documented per-bug worktrees, independent reviews, three-way verdicts, and human triage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->