### PR TITLE
Add Backbrief Kit to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Workflows that coordinate multiple AI agents working in parallel or sequence.
 - [agent-council](https://github.com/team-attention/agent-council) - Multi-agent collaboration plugin orchestrating multiple AI agents (Codex CLI, Gemini CLI) for diverse perspectives on the same task. 118 stars.
 - [Solopreneur kickoff](https://github.com/pcatattacks/solopreneur-plugin) - Agent team meetings where 6 specialist agents debate approach before building.
 - [wshobson/agents](https://github.com/wshobson/agents) - Intelligent automation and multi-agent orchestration for Claude Code with specialized agent roles and coordinated task execution.
+- [Backbrief Kit](https://github.com/charlesashe/backbrief-kit) - Orchestrator decomposes a goal into units and routes each to a specialist agent, then a separate verifier re-reads the finished artifact in fresh context against its acceptance criteria before it is called done. Combines subagents + slash commands + shared rules every agent obeys + an opt-in SessionStart hook that re-injects the newest handoff brief and decision-log tail after startup, /clear, and compaction.
 
 ## Context and Memory Management
 


### PR DESCRIPTION
Adds one workflow to **Multi-Agent Orchestration**.

**What it does:** an orchestrator decomposes a goal into units with acceptance criteria and routes each to the specialist agent that fits it; a separate verifier then re-reads the finished artifact in fresh context — it never sees the producing agent's reasoning or draft history — and checks it against those criteria before the work is called done.

**Primitives combined:** subagents + slash commands + a rules layer every agent obeys + an opt-in `SessionStart` hook (matcher `startup|clear|compact`) that re-injects the newest handoff brief and the tail of the decision log, so a fresh chat and a post-compaction context both start knowing where the project stands.

**Setup:** `/plugin marketplace add charlesashe/backbrief-kit` then `/plugin install backbrief-kit@backbrief`, or install from the zip at backbrief.ai.

**Notes against your quality standards:** actively maintained (last commit 2026-08-26), and it is what I run my own projects on daily. Free to use; the license is source-available and custom, not OSI — it permits use, modification for your own use, and unmodified free sharing, and forbids resale. I left star counts and component counts out of the description deliberately: the counts change on nearly every release and go stale in a list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Backbrief Kit to the Multi-Agent Orchestration section.
  * Documented goal decomposition, specialist routing, independent verification, shared rules, slash commands, and optional session-start context recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->