### PR TITLE
Add Wayfinder to Context and Memory Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Workflows for managing Claude Code's context window, memory persistence, and ses
 
 - [claude-mem](https://github.com/thedotmack/claude-mem) - Plugin that auto-captures everything Claude does, compresses it with AI via Agent SDK, and injects relevant context back into future sessions. 39,615 stars.
 - [Continuous Claude v3](https://github.com/parcadei/Continuous-Claude-v3) - Context management via hooks that maintain state through ledgers and handoffs. MCP execution without context pollution. Agent orchestration with isolated context windows. 3,619 stars.
+- [Wayfinder](https://github.com/WBXWHT/wayfinder) - Captures prompts, tool activity, file changes, validation evidence, and user verdicts through Claude Code hooks, then combines a bundled skill with a read-only MCP App to turn each session into a branching voyage map for failure diagnosis and reuse.
 - [arscontexta](https://github.com/agenticnotetaking/arscontexta) - Plugin that generates individualized knowledge systems from conversation — you describe how you think, and get a complete second brain as markdown files. 2,824 stars.
 - [Claude Code Development Kit](https://github.com/peterkrueck/Claude-Code-Development-Kit) - Handle context at scale with custom workflows combining hooks, MCP, and sub-agents working together. 1,330 stars.
 - [runesleo/claude-code-workflow](https://github.com/runesleo/claude-code-workflow) - Battle-tested template for memory management, context engineering, and task routing from 3 months of daily usage. 521 stars.


### PR DESCRIPTION
## Summary

Add Wayfinder to the Context and Memory Management section.

Wayfinder is an actively maintained, local-first workflow that combines three Claude Code primitives:

- hooks capture prompts, tool activity, file changes, validation evidence, and user verdicts;
- a bundled skill installs and diagnoses the capture workflow;
- a read-only MCP server and MCP App render the resulting branching voyage map.

## Verification

- Repository: https://github.com/WBXWHT/wayfinder
- Release: https://github.com/WBXWHT/wayfinder/releases/tag/v0.3.3
- Official MCP Registry: `io.github.WBXWHT/wayfinder`, active version `0.3.3`
- Tests: https://github.com/WBXWHT/wayfinder/actions/runs/34200350782
- Anthropic plugin validation: `npx @anthropic-ai/claude-code@2.1.263 plugin validate` passed for the submitted plugin directory

The entry describes only the Claude Code hook, skill, and read-only MCP workflow; it does not claim separate IDE-only restore actions as Claude plugin capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for the Wayfinder tool, including its context and memory management capabilities.
  - Described how it captures prompts, tool activity, file changes, validation evidence, and user verdicts.
  - Documented branching voyage maps for diagnosing and reusing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->